### PR TITLE
Demo doesn't need to close

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -68,6 +68,11 @@
 
             galleryOptions = {
               index: 0,
+              escKey: false,
+              modal: false,
+              clickToCloseNonZoomable: false,
+              closeEl:false,
+              closeOnScroll: false,
               counterEl: false // no slide counter
             },
             gallerySetup = function(gallery) {


### PR DESCRIPTION
For the single-gallery demo, there's no real need to close it. So disable closing via escape key, close button, scrolling, clicking on non-zoomable images.

It'd be nice to disable closing from clicking the black background, do you know how to do that too?