### PR TITLE
Get API key or album ID from URL or prompt

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -85,6 +85,14 @@
               reopenLink.style.display = '';
             };
 
+        if (flickrApiKey == 'FILL-ME-IN') {
+          flickrApiKey = prompt('Enter a Flickr API key:');
+          if (flickrApiKey == null) {
+            alert('You have to fill in your Flickr API key for the script to work.');
+            return;
+          }
+        }
+
         if (flickrPhotosetId == 'FILL-ME-IN') {
           // Look for album ID in URL: example.com/demo.html#aid=ID
           var locHash = location.hash.substr(1),
@@ -96,16 +104,14 @@
             ret = prompt('Enter a Flickr album URL or ID:');
           }
 
-          // Get ID from https://www.flickr.com/photos/user/albums/ID or ID
-          flickrPhotosetId = ret.split('/').pop() || ret;
+          if (ret != null) {
+            // Get ID from https://www.flickr.com/photos/user/albums/ID or ID
+            flickrPhotosetId = ret.split('/').pop() || ret;
+          }
         }
-
-        if (flickrApiKey == 'FILL-ME-IN' || flickrPhotosetId == 'FILL-ME-IN')
-        {
-          alert('You have to fill in your flickr API key and photoset ID for the script to work.');
-        }
-        else
-        {
+        if (flickrPhotosetId == 'FILL-ME-IN') {
+          alert('You have to fill in a Flickr album ID for the script to work.');
+        } else {
           photoswipeFlickr(flickrApiKey,flickrPhotosetId, galleryOptions, gallerySetup);
           reopenLink.addEventListener('click', function(){ photoswipeFlickr.initGallery(gallerySetup); });
         }

--- a/demo.html
+++ b/demo.html
@@ -94,10 +94,14 @@
             };
 
         if (flickrApiKey == 'FILL-ME-IN') {
-          flickrApiKey = prompt('Enter a Flickr API key:');
+          // Look for API key in URL: example.com/demo.html#key=API_key
+          var flickrApiKey = getHashParameter('key');
           if (flickrApiKey == null) {
-            alert('You have to fill in your Flickr API key for the script to work.');
-            return;
+            flickrApiKey = prompt('Enter a Flickr API key:');
+            if (flickrApiKey == null) {
+              alert('You have to fill in your Flickr API key for the script to work.');
+              return;
+            }
           }
         }
 

--- a/demo.html
+++ b/demo.html
@@ -59,6 +59,14 @@
     <script src="photoswipe-flickr.js"></script>
 
     <script>
+      var getHashParameter = function(name) {
+        var locHash = location.hash.substr(1),
+            ret     = locHash.substr(locHash.indexOf(name + '='))
+                       .split('&')[0]
+                       .split('=')[1];
+        return ret;
+      };
+
       var onload = function() {
         var flickrApiKey = 'FILL-ME-IN',
             flickrPhotosetId = 'FILL-ME-IN',
@@ -95,10 +103,7 @@
 
         if (flickrPhotosetId == 'FILL-ME-IN') {
           // Look for album ID in URL: example.com/demo.html#aid=ID
-          var locHash = location.hash.substr(1),
-              ret     = locHash.substr(locHash.indexOf('aid='))
-                         .split('&')[0]
-                         .split('=')[1];
+          var ret = getHashParameter('aid');
 
           if (ret == null) {
             ret = prompt('Enter a Flickr album URL or ID:');

--- a/demo.html
+++ b/demo.html
@@ -85,6 +85,12 @@
               reopenLink.style.display = '';
             };
 
+        if (flickrPhotosetId == 'FILL-ME-IN') {
+          // Get ID from https://www.flickr.com/photos/user/albums/ID or ID
+          ret = prompt('Enter a Flickr album URL or ID:');
+          flickrPhotosetId = ret.split('/').pop() || ret;
+        }
+
         if (flickrApiKey == 'FILL-ME-IN' || flickrPhotosetId == 'FILL-ME-IN')
         {
           alert('You have to fill in your flickr API key and photoset ID for the script to work.');
@@ -98,9 +104,6 @@
 
       if (document.readyState != 'loading') {
         onload();
-      }
-      else {
-        document.addEventListener('DOMContentLoaded', onload);
       }
     </script>
   </body>

--- a/demo.html
+++ b/demo.html
@@ -86,8 +86,17 @@
             };
 
         if (flickrPhotosetId == 'FILL-ME-IN') {
+          // Look for album ID in URL: example.com/demo.html#aid=ID
+          var locHash = location.hash.substr(1),
+              ret     = locHash.substr(locHash.indexOf('aid='))
+                         .split('&')[0]
+                         .split('=')[1];
+
+          if (ret == null) {
+            ret = prompt('Enter a Flickr album URL or ID:');
+          }
+
           // Get ID from https://www.flickr.com/photos/user/albums/ID or ID
-          ret = prompt('Enter a Flickr album URL or ID:');
           flickrPhotosetId = ret.split('/').pop() || ret;
         }
 


### PR DESCRIPTION
This makes the demo a little bit more usable, if there's no hardcoded values.

Can do either: `demo.html#aid=ID`

or: `demo.html#key=API_key`

or: `demo.html#aid=ID&key=API_key`

If the values aren't hardcoded, or found in the URL, they're prompted for. If that's cancelled, the error is shown.

`aid` for album ID because PhotoSwipe itself uses `gid=1&pid=1`, but perhaps `album` would be more descriptive?

---

Also, if you go to https://github.com/lyoshenka/photoswipe-flickr/settings you can set your master branch to be published under GitHub Pages to get a working, hosted demo at https://lyoshenka.github.io/photoswipe-flickr/demo.html

![image](https://cloud.githubusercontent.com/assets/1324225/20980633/fcfa8b28-bcb9-11e6-993d-e8d19403f69e.png)

e.g. https://hugovk.github.io/photoswipe-flickr/demo.html

